### PR TITLE
Display logs on dashboard

### DIFF
--- a/client/src/features/logs.types.ts
+++ b/client/src/features/logs.types.ts
@@ -1,6 +1,7 @@
 export type Log = {
   _id: string
-  date: string
+  start_date: string
+  running_time_in_seconds: number
   log: string
   type: 'github' | 'datocms'
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client/src/features/logs.types.ts
+++ b/client/src/features/logs.types.ts
@@ -1,9 +1,22 @@
+export type GithubCommitAuthor = {
+  name: string
+  date: string
+}
+
+export type GithubCommitData = {
+  sha: string
+  html_url: string
+  commit: {
+    message: string
+    author: GithubCommitAuthor
+  }
+}
+
 export type Log = {
   _id: string
   start_date: string
   running_time_in_seconds: number
   log: string
   type: 'github' | 'datocms'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  github_commit_data?: Record<string, any>
+  github_commit_data?: GithubCommitData
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { fetchAllLogs } from '@/features/logs'
+import type { Log } from '@/features/logs.types'
 
 export const Dashboard = () => {
   const allLogs = useQuery({ queryKey: ['logs'], queryFn: fetchAllLogs })
@@ -11,20 +12,28 @@ export const Dashboard = () => {
 
   if (allLogs.data) {
     return (
-      <>
-        {allLogs.data.map((log) => (
-          <div
+      <div className='flex flex-col gap-4'>
+        {allLogs.data.map((log: Log) => (
+          <article
             key={log._id}
-            className='border border-solid border-text p-5 bg-background h-full box-border flex justify-center items-start rounded-md min-h-0 text-center'
+            className='border border-solid border-text p-5 bg-background rounded-md flex flex-col gap-2'
           >
-            {log.type}
-            Ready main
-            {new Date(log.date).toLocaleString()}
-            {log.github_commit_data?.sha}
-            {log.github_commit_data?.commit?.message}
-          </div>
+            <header className='text-sm flex flex-col'>
+              <span className='font-bold uppercase'>{log.type}</span>
+              <span>{new Date(log.start_date).toLocaleString()}</span>
+              {log.github_commit_data?.sha && (
+                <span>{log.github_commit_data.sha}</span>
+              )}
+              {log.github_commit_data?.commit?.message && (
+                <span>{log.github_commit_data.commit.message}</span>
+              )}
+            </header>
+            <pre className='whitespace-pre-wrap break-words text-left text-sm'>
+              {log.log}
+            </pre>
+          </article>
         ))}
-      </>
+      </div>
     )
   }
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -18,19 +18,33 @@ export const Dashboard = () => {
             key={log._id}
             className='border border-solid border-text p-5 bg-background rounded-md flex flex-col gap-2'
           >
-            <header className='text-sm flex flex-col'>
+            <header className='text-sm flex flex-col gap-1'>
               <span className='font-bold uppercase'>{log.type}</span>
               <span>{new Date(log.start_date).toLocaleString()}</span>
-              {log.github_commit_data?.sha && (
-                <span>{log.github_commit_data.sha}</span>
-              )}
-              {log.github_commit_data?.commit?.message && (
-                <span>{log.github_commit_data.commit.message}</span>
+              {log.github_commit_data && (
+                <>
+                  <a
+                    href={log.github_commit_data.html_url}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='underline text-blue-600'
+                  >
+                    {log.github_commit_data.commit.message}
+                  </a>
+                  <span>
+                    {log.github_commit_data.commit.author.name}{' '}
+                    ({new Date(log.github_commit_data.commit.author.date).toLocaleString()})
+                  </span>
+                  <span className='text-xs'>{log.github_commit_data.sha}</span>
+                </>
               )}
             </header>
             <pre className='whitespace-pre-wrap break-words text-left text-sm'>
               {log.log}
             </pre>
+            <footer className='text-xs text-gray-500'>
+              Runtime: {Math.round(log.running_time_in_seconds)}s
+            </footer>
           </article>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- show log text for each entry in dashboard
- update log type definitions

## Testing
- `npm test`
- `npm --prefix client run lint` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_683f4aa95da8832f91c087dc4bfd7868